### PR TITLE
[DOP-9787] Allow passing Decimal as input for ColumnIntHWM

### DIFF
--- a/docs/changelog/next_release/58.feature.rst
+++ b/docs/changelog/next_release/58.feature.rst
@@ -1,0 +1,1 @@
+Allow to pass float and Decimal values as valid input for ``ColumnIntHWM`` (but only if value does contain only ``0`` after decimal part).

--- a/etl_entities/hwm/hwm_type_registry.py
+++ b/etl_entities/hwm/hwm_type_registry.py
@@ -83,7 +83,7 @@ class HWMTypeRegistry:
 
         result = cls._mapping.inverse.get(klass)
         if not result:
-            raise KeyError(f"You should registered {klass} class using @register_hwm_type decorator")
+            raise KeyError(f"You should register {klass} class using @register_hwm_type decorator")
 
         return result
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/etl-entities/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Allow to pass Decimal and float input for ColumnIntHWM, but only if value does contain only `0` after decimal point - `1.000` is valid, `1.002` is not.

This allows to drop custom DecimalHWM class from onETL.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/etl-entities/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
