### PR TITLE
[DOP-11304] Simplify comparison methods implementation

### DIFF
--- a/docs/changelog/next_release/61.breaking.1.rst
+++ b/docs/changelog/next_release/61.breaking.1.rst
@@ -1,0 +1,2 @@
+Disallow comparison ``hwm < raw_value`` and ``hwm > raw_value`` where ``raw_value`` is a primitive type value, like int.
+This now raises ``TypeError``.

--- a/docs/changelog/next_release/61.breaking.2.rst
+++ b/docs/changelog/next_release/61.breaking.2.rst
@@ -1,0 +1,1 @@
+Disallow passing extra fields to HWM class constructors instead of silently ignore them.

--- a/etl_entities/hwm/column/date_hwm.py
+++ b/etl_entities/hwm/column/date_hwm.py
@@ -73,137 +73,16 @@ class ColumnDateHWM(ColumnHWM[date]):
     value: Optional[date] = None
 
     @validator("value", pre=True)
-    def validate_value(cls, value):  # noqa: N805
-        if isinstance(value, (str, int)):
-            return cls._deserialize_value(value)
+    def _validate_value(cls, value):  # noqa: N805
         # we need to deserialize values, as pydantic parses fields in unexpected way:
         # https://docs.pydantic.dev/latest/api/standard_library_types/#datetimedatetime
+        if isinstance(value, int):
+            raise ValueError("Cannot convert integer to date")
+
+        if isinstance(value, str):
+            result = strict_str_validator(value).strip()
+            if result.lower() == "null":
+                return None
+            return date.fromisoformat(result)
+
         return value
-
-    def __eq__(self, other):
-        """Checks equality of two HWM instances
-
-        Params
-        -------
-        other : :obj:`etl_entities.hwm.date_hwm.ColumnDateHWM` or :obj:`datetime.date`
-
-            Should be comparable with ``value`` attribute type.
-
-            You can compare two :obj:`hwmlib.hwm.date_hwm.ColumnDateHWM` or ``date`` values.
-
-            But you cannot compare ``date`` with ``int`` value,
-            as well as different HWM types,
-            like :obj:`hwmlib.hwm.date_hwm.ColumnDateHWM` and :obj:`hwmlib.hwm.int_hwm.ColumnIntHWM`.
-
-        Returns
-        --------
-        result : bool
-
-            ``True`` if both inputs are the same, ``False`` otherwise.
-
-        Examples
-        ----------
-
-        .. code:: python
-
-            from datetime import date
-            from etl_entities.hwm import ColumnDateHWM
-
-            hwm1 = ColumnDateHWM(value=date(year=2021, month=12, day=30), ...)
-            hwm2 = ColumnDateHWM(value=date(year=2021, month=12, day=31), ...)
-
-            assert hwm1 == hwm1
-            assert hwm1 != hwm2
-        """
-
-        if isinstance(other, ColumnHWM) and not isinstance(other, ColumnDateHWM):
-            return False
-
-        return super().__eq__(other)
-
-    def __lt__(self, other):
-        """Checks current HWM value is less than another one
-
-        Params
-        -------
-        other : :obj:`etl_entities.hwm.date_hwm.ColumnDateHWM` or :obj:`datetime.date`
-
-            Should be comparable with ``value`` attribute type.
-
-            You can compare two :obj:`hwmlib.hwm.date_hwm.ColumnDateHWM` or ``date`` values.
-
-            But you cannot compare ``date`` with ``int`` value,
-            as well as different HWM types,
-            like :obj:`hwmlib.hwm.date_hwm.ColumnDateHWM` and :obj:`hwmlib.hwm.int_hwm.ColumnIntHWM`.
-
-            .. warning::
-
-                You cannot compare HWMs if one of them has None value
-
-        Returns
-        --------
-        result : bool
-
-            ``True`` if current HWM value is less than provided value, ``False`` otherwise.
-
-        Examples
-        ----------
-
-        .. code:: python
-
-            from datetime import date
-            from etl_entities.hwm import ColumnDateHWM
-
-            hwm1 = DateHWM(value=date(year=2021, month=12, day=30), ...)
-            hwm2 = DateHWM(value=date(year=2021, month=12, day=31), ...)
-
-            assert hwm1 < hwm2
-            assert hwm2 > hwm1
-
-            assert hwm1 < date(year=2021, month=12, day=1)
-            assert hwm1 > date(year=2021, month=12, day=31)
-
-            hwm3 = ColumnDateHWM(value=None, ...)
-            assert hwm1 < hwm3  # will raise TypeError
-            assert hwm1 < None  # same thing
-        """
-
-        if isinstance(other, ColumnHWM) and not isinstance(other, ColumnDateHWM):
-            return NotImplemented
-
-        return super().__lt__(other)
-
-    @classmethod
-    def _deserialize_value(cls, value: str) -> date | None:
-        """Parse string representation to get HWM value
-
-        Parameters
-        ----------
-        value : str
-
-            Serialized value
-
-        Returns
-        -------
-        result : :obj:`datetime.date` or ``None``
-
-            Deserialized value
-
-        Examples
-        ----------
-
-        .. code:: python
-
-            from etl_entities.hwm import ColumnDateHWM
-
-            assert ColumnDateHWM.deserialize_value("2021-12-31") == date(
-                year=2021, month=12, day=31
-            )
-            assert ColumnDateHWM.deserialize_value("null") is None
-        """
-
-        result = strict_str_validator(value).strip()
-
-        if result.lower() == "null":
-            return None
-        return date.fromisoformat(result)

--- a/etl_entities/hwm/column/datetime_hwm.py
+++ b/etl_entities/hwm/column/datetime_hwm.py
@@ -74,147 +74,17 @@ class ColumnDateTimeHWM(ColumnHWM[datetime]):
     value: Optional[datetime] = None
 
     @validator("value", pre=True)
-    def validate_value(cls, value):  # noqa: N805
-        if isinstance(value, (str, int)):
-            return cls._deserialize_value(value)
+    def _validate_value(cls, value):  # noqa: N805
         # we need to deserialize values, as pydantic parses fields in unexpected way:
         # https://docs.pydantic.dev/latest/api/standard_library_types/#datetimedatetime
+        if isinstance(value, int):
+            raise ValueError("Cannot convert integer to datetime")
+
+        if isinstance(value, str):
+            result = strict_str_validator(value).strip()
+            if result.lower() == "null":
+                return None
+
+            return datetime.fromisoformat(result)
+
         return value
-
-    def __eq__(self, other):
-        """Checks equality of two HWM instances
-
-        Params
-        -------
-        other : :obj:`etl_entities.hwm.datetime_hwm.ColumnDateTimeHWM` or :obj:`datetime.datetime`
-
-            Should be comparable with ``value`` attribute type.
-
-            You can compare two :obj:`hwmlib.hwm.datetime_hwm.ColumnDateTimeHWM` or ``datetime`` values.
-
-            But you cannot compare ``datetime`` with ``int`` value,
-            as well as different HWM types,
-            like :obj:`hwmlib.hwm.datetime_hwm.ColumnDateTimeHWM` and :obj:`hwmlib.hwm.int_hwm.ColumnIntHWM`.
-
-        Returns
-        --------
-        result : bool
-
-            ``True`` if both inputs are the same, ``False`` otherwise.
-
-        Examples
-        ----------
-
-        .. code:: python
-
-            from datetime import datetime
-            from etl_entities.hwm import ColumnDateTimeHWM
-
-            hwm1 = ColumnDateTimeHWM(
-                value=datetime(year=2021, month=12, day=30, hour=11, minute=22, second=33), ...
-            )
-            hwm2 = ColumnDateTimeHWM(
-                value=datetime(year=2021, month=12, day=31, hour=1, minute=11, second=22), ...
-            )
-
-            assert hwm1 == hwm1
-            assert hwm1 != hwm2
-        """
-
-        if isinstance(other, ColumnHWM) and not isinstance(other, ColumnDateTimeHWM):
-            return False
-
-        return super().__eq__(other)
-
-    def __lt__(self, other):
-        """Checks current HWM value is less than another one
-
-        Params
-        -------
-        other : :obj:`etl_entities.hwm.datetime_hwm.ColumnDateTimeHWM` or :obj:`datetime.datetime`
-
-            Should be comparable with ``value`` attribute type.
-
-            You can compare two :obj:`hwmlib.hwm.datetime_hwm.ColumnDateTimeHWM` or ``datetime`` values.
-
-            But you cannot compare ``datetime`` with ``int`` value,
-            as well as different HWM types,
-            like :obj:`hwmlib.hwm.datetime_hwm.ColumnDateTimeHWM` and :obj:`hwmlib.hwm.int_hwm.ColumnIntHWM`.
-
-            .. warning::
-
-                You cannot compare HWMs if one of them has ``None`` value
-
-        Returns
-        --------
-        result : bool
-
-            ``True`` if current HWM value is less than provided value, ``False`` otherwise.
-
-        Examples
-        ----------
-
-        .. code:: python
-
-            from datetime import datetime
-            from etl_entities.hwm import ColumnDateTimeHWMxw
-
-            hwm1 = ColumnDateTimeHWM(
-                value=datetime(year=2021, month=12, day=30, hour=11, minute=22, second=33), ...
-            )
-            hwm2 = ColumnDateTimeHWM(
-                value=datetime(year=2021, month=12, day=31, hour=00, minute=11, second=22), ...
-            )
-
-            assert hwm1 < hwm2
-            assert hwm2 > hwm1
-
-            assert hwm1 < datetime(year=2021, month=12, day=31, hour=1, minute=11, second=22)
-            assert hwm1 > datetime(year=2021, month=12, day=30, hour=11, minute=22, second=33)
-
-            hwm3 = ColumnDateTimeHWM(value=None, ...)
-            assert hwm1 < hwm3  # will raise TypeError
-            assert hwm1 < None  # same thing
-        """
-
-        if isinstance(other, ColumnHWM) and not isinstance(other, ColumnDateTimeHWM):
-            return NotImplemented
-
-        return super().__lt__(other)
-
-    @classmethod
-    def _deserialize_value(cls, value: str) -> datetime | None:
-        """Parse string representation to get HWM value
-
-        Parameters
-        ----------
-        value : str
-
-            Serialized value
-
-        Returns
-        -------
-        result : :obj:`datetime.datetime` or ``None``
-
-            Deserialized value
-
-        Examples
-        ----------
-
-        .. code:: python
-
-            from datetime import datetime
-            from etl_entities.hwm import ColumnDateTimeHWM
-
-            assert ColumnDateTimeHWM.deserialize_value("2021-12-31T11-22-33") == datetime(
-                year=2021, month=12, day=31, hour=11, minute=22, second=33
-            )
-
-            assert ColumnDateTimeHWM.deserialize_value("null") is None
-        """
-
-        result = strict_str_validator(value).strip()
-
-        if result.lower() == "null":
-            return None
-        return datetime.fromisoformat(result)

--- a/etl_entities/hwm/column/int_hwm.py
+++ b/etl_entities/hwm/column/int_hwm.py
@@ -71,8 +71,8 @@ class ColumnIntHWM(ColumnHWM[int]):
     value: Optional[StrictInt] = None
 
     @validator("value", pre=True)
-    def validate_value(cls, raw_value):  # noqa: N805
-        if raw_value is None:
+    def _validate_value(cls, raw_value):  # noqa: N805
+        if raw_value is None or raw_value == "null":
             return None
 
         if isinstance(raw_value, str):
@@ -88,90 +88,3 @@ class ColumnIntHWM(ColumnHWM[int]):
 
         # pydantic will raise validation error
         return raw_value
-
-    def __eq__(self, other):
-        """Checks equality of two HWM instances
-
-        Params
-        -------
-        other : :obj:`hwmlib.hwm.int_hwm.ColumnIntHWM` or :obj:`int`
-
-            Should be comparable with ``value`` attribute type.
-
-            You can compare two ``int`` values, but you cannot compare ``int`` with ``date`` value,
-            as well as different HWM types,
-            like :obj:`hwmlib.hwm.int_hwm.ColumnIntHWM` and :obj:`hwmlib.hwm.date_hwm.ColumnDateHWM`.
-
-        Returns
-        --------
-        result : bool
-
-            ``True`` if both inputs are the same, ``False`` otherwise.
-
-        Examples
-        ----------
-
-        .. code:: python
-
-            from etl_entities.hwm import ColumnIntHWM
-
-            hwm1 = ColumnIntHWM(value=1, ...)
-            hwm2 = ColumnIntHWM(value=2, ...)
-
-            assert hwm1 == hwm1
-            assert hwm1 != hwm2
-        """
-
-        if isinstance(other, ColumnHWM) and not isinstance(other, ColumnIntHWM):
-            return False
-
-        return super().__eq__(other)
-
-    def __lt__(self, other):
-        """Checks current ColumnIntHWM value is less than another one
-
-        Params
-        -------
-        other : :obj:`hwmlib.hwm.int_hwm.ColumnIntHWM` or :obj:`int`
-
-            Should be comparable with ``value`` attribute type.
-
-            You can compare two ``int`` values, but you cannot compare ``int`` with ``date`` value,
-            as well as different HWM types,
-            like :obj:`hwmlib.hwm.int_hwm.ColumnIntHWM` and :obj:`hwmlib.hwm.date_hwm.ColumnDateHWM`.
-
-            .. warning::
-
-                You cannot compare HWMs if one of them has None value
-
-        Returns
-        --------
-        result : bool
-
-            ``True`` if current HWM value is less than provided value, ``False`` otherwise.
-
-        Examples
-        ----------
-
-        .. code:: python
-
-            from etl_entities.hwm import ColumnIntHWM
-
-            hwm1 = ColumnIntHWM(value=1, ...)
-            hwm2 = ColumnIntHWM(value=2, ...)
-
-            assert hwm1 < hwm2
-            assert hwm1 > hwm2
-
-            assert hwm1 < 2
-            assert hwm1 > 0
-
-            hwm3 = ColumnIntHWM(value=None, ...)
-            assert hwm1 < hwm3  # will raise TypeError
-            assert hwm1 < None  # same thing
-        """
-
-        if isinstance(other, ColumnHWM) and not isinstance(other, ColumnIntHWM):
-            return NotImplemented
-
-        return super().__lt__(other)

--- a/etl_entities/hwm/file/file_hwm.py
+++ b/etl_entities/hwm/file/file_hwm.py
@@ -15,8 +15,7 @@
 from __future__ import annotations
 
 import os
-from abc import abstractmethod
-from typing import Generic, Iterable, Optional, TypeVar
+from typing import Generic, Optional, TypeVar
 
 from pydantic import Field, validator
 
@@ -68,10 +67,6 @@ class FileHWM(
     class Config:  # noqa: WPS431
         json_encoders = {AbsolutePath: os.fspath}
 
-    @abstractmethod
-    def update(self, value: str | os.PathLike | Iterable[str | os.PathLike]):
-        """Updates current HWM value with some implementation-specific logic, and return HWM."""
-
     def __eq__(self, other):
         """Checks equality of two FileHWM instances
 
@@ -86,8 +81,8 @@ class FileHWM(
             ``True`` if both inputs are the same, ``False`` otherwise
         """
 
-        if not isinstance(other, FileHWM):
-            return False
+        if not isinstance(other, type(self)):
+            return NotImplemented
 
         self_fields = self.dict(exclude={"modified_time"})
         other_fields = other.dict(exclude={"modified_time"})

--- a/etl_entities/hwm/file/file_list_hwm.py
+++ b/etl_entities/hwm/file/file_list_hwm.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import os
-from typing import FrozenSet, Iterable
+from typing import FrozenSet, Iterable, TypeVar
 
 from pydantic import Field, validator
 
@@ -24,6 +24,7 @@ from etl_entities.hwm.hwm_type_registry import register_hwm_type
 from etl_entities.instance import AbsolutePath
 
 FileListType = FrozenSet[AbsolutePath]
+FileListHWMType = TypeVar("FileListHWMType", bound="FileListHWM")
 
 
 @register_hwm_type("file_list")
@@ -90,7 +91,7 @@ class FileListHWM(FileHWM[FileListType]):
 
         return value in self
 
-    def update(self, value: str | os.PathLike | Iterable[str | os.PathLike]):
+    def update(self: FileListHWMType, value: str | os.PathLike | Iterable[str | os.PathLike]) -> FileListHWMType:
         """Updates current HWM value with some implementation-specific logic, and return HWM.
 
         .. note::
@@ -138,7 +139,7 @@ class FileListHWM(FileHWM[FileListType]):
 
         return self
 
-    def __add__(self, value: str | os.PathLike | Iterable[str | os.PathLike]):
+    def __add__(self: FileListHWMType, value: str | os.PathLike | Iterable[str | os.PathLike]) -> FileListHWMType:
         """Adds path or paths to HWM value, and return copy of HWM
 
         Params
@@ -173,7 +174,7 @@ class FileListHWM(FileHWM[FileListType]):
 
         return self
 
-    def __sub__(self, value: str | os.PathLike | Iterable[str | os.PathLike]):
+    def __sub__(self: FileListHWMType, value: str | os.PathLike | Iterable[str | os.PathLike]) -> FileListHWMType:
         """Remove path or paths from HWM value, and return copy of HWM
 
         Params
@@ -228,7 +229,7 @@ class FileListHWM(FileHWM[FileListType]):
             hwm = FileListHWM(value={"/some/path"}, ...)
 
             assert "/some/path" in hwm
-            assert "/another/path" in hwm
+            assert "/another/path" not in hwm
         """
 
         if isinstance(item, str):
@@ -238,38 +239,6 @@ class FileListHWM(FileHWM[FileListType]):
             item = AbsolutePath(item)
 
         return item in self.value
-
-    def __eq__(self, other):
-        """Checks equality of two FileListHWM instances
-
-        Params
-        -------
-        other : :obj:`etl_entities.hwm.file_list_hwm.FileListHWM`
-
-        Returns
-        --------
-        result : bool
-
-            ``True`` if both inputs are the same, ``False`` otherwise.
-
-        Examples
-        ----------
-
-        .. code:: python
-
-            from etl_entities.hwm import FileListHWM
-
-            hwm1 = FileListHWM(value={"/some"}, ...)
-            hwm2 = FileListHWM(value={"/another"}, ...)
-
-            assert hwm1 == hwm1
-            assert hwm1 != hwm2
-        """
-
-        if not isinstance(other, FileListHWM):
-            return False
-
-        return super().__eq__(other)
 
     @validator("value", pre=True)
     def _validate_value(cls, value, values: dict):  # noqa: N805

--- a/etl_entities/hwm/hwm.py
+++ b/etl_entities/hwm/hwm.py
@@ -26,6 +26,7 @@ from etl_entities.entity import GenericModel
 from etl_entities.hwm.hwm_type_registry import HWMTypeRegistry
 
 ValueType = TypeVar("ValueType")
+HWMType = TypeVar("HWMType", bound="HWM")
 
 
 class HWM(ABC, Generic[ValueType], GenericModel):
@@ -39,7 +40,7 @@ class HWM(ABC, Generic[ValueType], GenericModel):
 
     name : ``str``
 
-        HWM name
+        HWM unique name
 
     value : ``ColumnValueType`` or ``None``, default: ``None``
 
@@ -65,7 +66,10 @@ class HWM(ABC, Generic[ValueType], GenericModel):
     expression: Any = None
     modified_time: datetime = Field(default_factory=datetime.now)
 
-    def set_value(self, value: ValueType | None) -> HWM:
+    class Config:  # noqa: WPS431
+        extra = "forbid"
+
+    def set_value(self: HWMType, value: ValueType | None) -> HWMType:
         """Replaces current HWM value with the passed one, and return HWM.
 
         .. note::
@@ -130,7 +134,7 @@ class HWM(ABC, Generic[ValueType], GenericModel):
         return result
 
     @classmethod
-    def deserialize(cls, inp: dict):
+    def deserialize(cls: type[HWMType], inp: dict) -> HWMType:
         """Return HWM from dict representation
 
         Returns
@@ -168,7 +172,7 @@ class HWM(ABC, Generic[ValueType], GenericModel):
         return super().deserialize(value)
 
     @abstractmethod
-    def update(self, value):
+    def update(self: HWMType, value: Any) -> HWMType:
         """Update current HWM value with some implementation-specific logic, and return HWM"""
 
     @abstractmethod

--- a/tests/test_hwm/test_file_list_hwm.py
+++ b/tests/test_hwm/test_file_list_hwm.py
@@ -92,6 +92,10 @@ def test_file_list_hwm_wrong_input(invalid_file):
         # value does not match directory
         FileListHWM(name=name, value="/some/path/file.py", directory="/another/path")
 
+    with pytest.raises(ValueError):
+        # extra fields not allowed
+        FileListHWM(name=name, unknown="unknown")
+
 
 def test_file_list_hwm_set_value():
     file1 = "/some/path/file.py"
@@ -192,6 +196,10 @@ def test_file_list_hwm_compare():
         for item2 in items:
             if item1 is not item2:
                 assert item1 != item2
+
+    # this was true until 2.1.x, but not anymore
+    for item in items:
+        assert item != item.value
 
 
 def test_file_list_hwm_covers():

--- a/tests/test_hwm/test_hwm_type_registry.py
+++ b/tests/test_hwm/test_hwm_type_registry.py
@@ -1,3 +1,4 @@
+import secrets
 from datetime import date, datetime
 
 import pytest
@@ -24,24 +25,24 @@ from etl_entities.hwm import (
     ],
 )
 def test_column_hwm_parse(hwm_class, hwm_type, value, serialized_value):
-    column = "column_name"
-    name = "table_name"
+    name = secrets.token_hex()
+    table = "table_name"
     modified_time = datetime.now()
 
     serialized1 = {
         "value": serialized_value,
         "type": hwm_type,
-        "column": column,
+        "source": table,
         "name": name,
         "modified_time": modified_time.isoformat(),
     }
-    hwm1 = hwm_class(column=column, name=name, value=value, modified_time=modified_time)
+    hwm1 = hwm_class(name=name, source=table, value=value, modified_time=modified_time)
 
     assert HWMTypeRegistry.parse(serialized1) == hwm1
 
     serialized2 = serialized1.copy()
     serialized2["value"] = None
-    hwm2 = hwm_class(column=column, name=name, modified_time=modified_time)
+    hwm2 = hwm_class(name=name, source=table, modified_time=modified_time)
 
     assert HWMTypeRegistry.parse(serialized2) == hwm2
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/etl-entities/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

<!-- Please give a short summary of the changes. -->

1. Instead of rewriting `__eq__` and `__lt__` methods in every child class of ColumnHWM to check that other value has the same type as `self`, I moved this check to `ColumnHWM` class itself.
2. Disallow comparison like `hwm < value`, `hwm > value`, this is too magic.
3. Disallow passing extra fields to HWM constuctor, previous behavior may lead to WTF moments. Add related tests.
4. Update few methods type hints - instead of returning abstract `HWM` class they now explicitly return object of the same class as `self`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/etl-entities/blob/develop/CONTRIBUTING.rst) for details.)
* [X] My PR is ready to review.
