### PR TITLE
[DOP-14061] Replace asserts in documentation with doctest style

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,8 @@ jobs:
         run: |
           mkdir reports/ || echo "Directory exists"
           pip install -e . --no-build-isolation
-          ./run_tests.sh
+          # run both tests ad doctests
+          ./run_tests.sh etl_entities/hwm tests
 
       - name: Upload coverage results
         uses: actions/upload-artifact@v4

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,5 +2,5 @@ coverage:
   status:
     project:
       default:
-        target: 96%
+        target: 94%
         threshold: 1%

--- a/docs/changelog/next_release/91.improvement.rst
+++ b/docs/changelog/next_release/91.improvement.rst
@@ -1,0 +1,1 @@
+Replace all ``assert`` in documentation with doctest syntax. This should make documentation more readable.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,6 +96,12 @@ todo_include_todos = False
 # Output file base name for HTML help builder.
 htmlhelp_basename = "etl-entities-doc"
 
+# prevent >>>, ... and doctest outputs from copying
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_prompt_is_regexp = True
+copybutton_copy_empty_lines = False
+copybutton_only_copy_prompt_lines = True
+
 towncrier_draft_autoversion_mode = "draft"
 towncrier_draft_include_empty = False
 towncrier_draft_working_directory = PROJECT_ROOT_DIR

--- a/etl_entities/hwm/column/column_hwm.py
+++ b/etl_entities/hwm/column/column_hwm.py
@@ -69,15 +69,10 @@ class ColumnHWM(HWM[Optional[ColumnValueType]], Generic[ColumnValueType], Generi
         Examples
         --------
 
-        .. code:: python
-
-            # assume val2 == val1 + inc
-
-            hwm1 = ColumnHWM(value=val1, ...)
-            hwm2 = ColumnHWM(value=val2, ...)
-
-            # same as ColumnHWM(value=hwm1.value + inc, ...)
-            assert hwm1 + inc == hwm2
+        >>> hwm = ColumnHWM(value=100, name="my_hwm")
+        >>> hwm = hwm + 2
+        >>> hwm.value
+        102
         """
 
         new_value = self.value + value  # type: ignore[operator]
@@ -106,15 +101,10 @@ class ColumnHWM(HWM[Optional[ColumnValueType]], Generic[ColumnValueType], Generi
         Examples
         --------
 
-        .. code:: python
-
-            # assume val2 == val1 - dec
-
-            hwm1 = ColumnHWM(value=val1, ...)
-            hwm2 = ColumnHWM(value=val2, ...)
-
-            # same as ColumnHWM(value=hwm1.value - dec, ...)
-            assert hwm1 - dec == hwm2
+        >>> hwm = ColumnHWM(value=100, name="my_hwm")
+        >>> hwm = hwm - 2
+        >>> hwm.value
+        98
         """
 
         new_value = self.value - value  # type: ignore[operator]
@@ -164,17 +154,14 @@ class ColumnHWM(HWM[Optional[ColumnValueType]], Generic[ColumnValueType], Generi
         Examples
         --------
 
-        .. code:: python
-
-            from etl_entities.hwm import ColumnIntHWM
-
-            hwm = ColumnIntHWM(value=1, ...)
-
-            hwm.update(2)
-            assert hwm.value == 2
-
-            hwm.update(1)
-            assert hwm.value == 2  # value cannot decrease
+        >>> from etl_entities.hwm import ColumnIntHWM
+        >>> hwm = ColumnIntHWM(value=1, name="my_hwm")
+        >>> hwm = hwm.update(2)
+        >>> hwm.value
+        2
+        >>> hwm = hwm.update(1)
+        >>> hwm.value  # value cannot decrease
+        2
         """
 
         if self.value is None:

--- a/etl_entities/hwm/file/file_list_hwm.py
+++ b/etl_entities/hwm/file/file_list_hwm.py
@@ -71,14 +71,12 @@ class FileListHWM(FileHWM[FileListType]):
         Examples
         --------
 
-        .. code:: python
-
-            from etl_entities.hwm import FileListHWM
-
-            hwm = FileListHWM(value={"some/path.py"}, ...)
-
-            assert hwm.covers("some/path.py")  # path in HWM
-            assert not hwm.covers("another/path.py")  # path not in HWM
+        >>> from etl_entities.hwm import FileListHWM
+        >>> hwm = FileListHWM(value={"/some/path.py"}, name="my_hwm")
+        >>> hwm.covers("/some/path.py")  # path in HWM
+        True
+        >>> hwm.covers("/another/path.py")  # path not in HWM
+        False
         """
 
         return value in self
@@ -99,30 +97,16 @@ class FileListHWM(FileHWM[FileListType]):
         Examples
         --------
 
-        .. code:: python
-
-            from etl_entities.hwm import FileListHWM
-            from etl_entities.instance import AbsolutePath
-
-            hwm = FileListHWM(value=["/some/existing_path.py"], ...)
-
-            # new paths are appended
-            hwm.update("/some/new_path.py")
-            assert hwm.value == frozenset(
-                {
-                    AbsolutePath("/some/existing_path.py"),
-                    AbsolutePath("/some/new_path.py"),
-                }
-            )
-
-            # existing paths do nothing
-            hwm.update("/some/existing_path.py")
-            assert hwm.value == frozenset(
-                {
-                    AbsolutePath("/some/existing_path.py"),
-                    AbsolutePath("/some/new_path.py"),
-                }
-            )
+        >>> from etl_entities.hwm import FileListHWM
+        >>> hwm = FileListHWM(value=["/some/existing_path.py"], name="my_hwm")
+        >>> # new paths are appended
+        >>> hwm = hwm.update("/some/new_path.py")
+        >>> sorted(hwm.value)
+        [AbsolutePath('/some/existing_path.py'), AbsolutePath('/some/new_path.py')]
+        >>> # existing path already here
+        >>> hwm = hwm.update("/some/existing_path.py")
+        >>> sorted(hwm.value)
+        [AbsolutePath('/some/existing_path.py'), AbsolutePath('/some/new_path.py')]
         """
 
         new_value = self.value | self._check_new_value(value)
@@ -149,15 +133,11 @@ class FileListHWM(FileHWM[FileListType]):
         Examples
         --------
 
-        .. code:: python
-
-            from etl_entities.hwm import FileListHWM
-
-            hwm1 = FileListHWM(value={"some/path"}, ...)
-            hwm2 = FileListHWM(value={"some/path", "another.file"}, ...)
-
-            assert hwm1 + "another.file" == hwm2
-            # same as FileListHWM(value=hwm1.value | {"another.file"}, ...)
+        >>> from etl_entities.hwm import FileListHWM
+        >>> hwm = FileListHWM(value={"/some/path"}, name="my_hwm")
+        >>> hwm = hwm + "/another.file"
+        >>> sorted(hwm.value)
+        [AbsolutePath('/another.file'), AbsolutePath('/some/path')]
         """
 
         new_value = self.value | self._check_new_value(value)
@@ -184,15 +164,11 @@ class FileListHWM(FileHWM[FileListType]):
         Examples
         --------
 
-        .. code:: python
-
-            from etl_entities.hwm import FileListHWM
-
-            hwm1 = FileListHWM(value={"some/path"}, ...)
-            hwm2 = FileListHWM(value={"some/path", "another.file"}, ...)
-
-            assert hwm1 - "another.file" == hwm2
-            # same as FileListHWM(value=hwm1.value - {"another.file"}, ...)
+        >>> from etl_entities.hwm import FileListHWM
+        >>> hwm = FileListHWM(value={"/some/path", "/another.file"}, name="my_hwm")
+        >>> hwm = hwm - "/another.file"
+        >>> sorted(hwm.value)
+        [AbsolutePath('/some/path')]
         """
 
         new_value = self.value - self._check_new_value(value)
@@ -213,15 +189,13 @@ class FileListHWM(FileHWM[FileListType]):
         Examples
         --------
 
-        .. code:: python
-
-            from etl_entities.hwm import FileListHWM
-            from etl_entities.instance import AbsolutePath
-
-            hwm = FileListHWM(value={"/some/path"}, ...)
-
-            assert "/some/path" in hwm
-            assert "/another/path" not in hwm
+        >>> from etl_entities.hwm import FileListHWM
+        >>> from etl_entities.instance import AbsolutePath
+        >>> hwm = FileListHWM(value={"/some/path"}, name="my_hwm")
+        >>> "/some/path" in hwm
+        True
+        >>> "/another/path" in hwm
+        False
         """
 
         if isinstance(item, str):

--- a/etl_entities/hwm/hwm.py
+++ b/etl_entities/hwm/hwm.py
@@ -75,14 +75,11 @@ class HWM(ABC, Generic[ValueType], GenericModel):
         Examples
         --------
 
-        .. code:: python
-
-            from etl_entities.hwm import ColumnIntHWM
-
-            hwm = ColumnIntHWM(value=1, ...)
-
-            hwm.set_value(2)
-            assert hwm.value == 2
+        >>> from etl_entities.hwm import ColumnIntHWM
+        >>> hwm = ColumnIntHWM(value=1, name="my_hwm")
+        >>> hwm = hwm.set_value(2)
+        >>> hwm.value
+        2
         """
 
         new_value = self._check_new_value(value)
@@ -105,18 +102,20 @@ class HWM(ABC, Generic[ValueType], GenericModel):
         Examples
         --------
 
-        .. code:: python
+        >>> from etl_entities.hwm import ColumnIntHWM
 
-            from etl_entities.hwm import ColumnIntHWM
-
-            hwm = ColumnIntHWM(value=1, ...)
-            assert hwm.serialize() == {
-                "value": "1",
-                "type": "int",
-                "column": "column_name",
-                "name": "table_name",
-                "description": ...,
-            }
+        >>> hwm = ColumnIntHWM(name="my_hwm", value=1, entity="some_column", description="some description")
+        >>> json = hwm.serialize()
+        >>> json["type"]
+        'column_int'
+        >>> json["name"]
+        'my_hwm'
+        >>> json["value"]
+        1
+        >>> json["entity"]
+        'some_column'
+        >>> json["description"]
+        'some description'
         """
 
         result = super().serialize()
@@ -135,21 +134,30 @@ class HWM(ABC, Generic[ValueType], GenericModel):
 
         Examples
         --------
-
-        .. code:: python
-
-            from etl_entities.hwm import ColumnIntHWM
-
-            assert ColumnIntHWM.deserialize(
-                {
-                    "value": "1",
-                    "type": "int",
-                    "column": "column_name",
-                    "name": "name",
-                }
-            ) == ColumnIntHWM(value=1, ...)
-
-            ColumnIntHWM.deserialize({"type": "date"})  # raises ValueError
+        >>> from etl_entities.hwm import ColumnIntHWM
+        >>> hwm = ColumnIntHWM.deserialize(
+        ...     {
+        ...         "type": "column_int",
+        ...         "name": "my_hwm",
+        ...         "value": "1",
+        ...         "entity": "some_column",
+        ...         "description": "some description",
+        ...     }
+        ... )
+        >>> type(hwm)
+        <class 'etl_entities.hwm.column.int_hwm.ColumnIntHWM'>
+        >>> hwm.name
+        'my_hwm'
+        >>> hwm.value
+        1
+        >>> hwm.entity
+        'some_column'
+        >>> hwm.description
+        'some description'
+        >>> ColumnIntHWM.deserialize({"type": "column_date"})
+        Traceback (most recent call last):
+            ...
+        ValueError: Type 'column_date' does not match class 'ColumnIntHWM'
         """
 
         value = deepcopy(inp)
@@ -157,7 +165,7 @@ class HWM(ABC, Generic[ValueType], GenericModel):
         if type_name:
             hwm_type = HWMTypeRegistry.get(type_name)
             if not issubclass(cls, hwm_type):
-                raise ValueError(f"Type {type_name} does not match class {cls.__name__}")
+                raise ValueError(f"Type {type_name!r} does not match class {cls.__qualname__!r}")
 
         return super().deserialize(value)
 

--- a/etl_entities/hwm/key_value/key_value_hwm.py
+++ b/etl_entities/hwm/key_value/key_value_hwm.py
@@ -76,19 +76,16 @@ class KeyValueHWM(HWM[frozendict], Generic[KeyValueHWMValueType], GenericModel):
         Examples
         --------
 
-        .. code:: python
-
-            from frozendict import frozendict
-            from etl_entities.hwm import KeyValueHWM
-
-            hwm = KeyValueHWM(value={0: 100, 1: 120}, ...)
-
-            hwm.update({1: 125, 2: 130})
-            assert hwm.value == frozendict({0: 100, 1: 125, 2: 130})
-
-            # The offset for partition 1 is not updated as 123 is less than 125
-            hwm.update({1: 123})
-            assert hwm.value == frozendict({0: 100, 1: 125, 2: 130})
+        >>> from frozendict import frozendict
+        >>> from etl_entities.hwm import KeyValueHWM
+        >>> hwm = KeyValueHWM(value={0: 100, 1: 120}, name="my_hwm")
+        >>> hwm = hwm.update({1: 125, 2: 130})
+        >>> hwm.value
+        frozendict.frozendict({0: 100, 1: 125, 2: 130})
+        >>> # Value for key 1 is not updated as 123 is less than current 125
+        >>> hwm = hwm.update({1: 123})
+        >>> hwm.value
+        frozendict.frozendict({0: 100, 1: 125, 2: 130})
         """
 
         modified = False

--- a/etl_entities/hwm/key_value/key_value_int_hwm.py
+++ b/etl_entities/hwm/key_value/key_value_int_hwm.py
@@ -66,31 +66,6 @@ class KeyValueIntHWM(KeyValueHWM[int]):
     value: frozendict = Field(default_factory=frozendict)
 
     def serialize(self) -> dict:
-        """Return dict representation of HWM
-
-        Returns
-        -------
-        result : dict
-
-            Serialized HWM
-
-        Examples
-        --------
-
-        .. code:: python
-
-            from etl_entities.hwm import ColumnIntHWM
-
-            hwm = ColumnIntHWM(value=1, ...)
-            assert hwm.serialize() == {
-                "value": "1",
-                "type": "int",
-                "column": "column_name",
-                "name": "table_name",
-                "description": ...,
-            }
-        """
-
         # Convert self.value to a regular dictionary if it is a frozendict
         # This is necessary because frozendict objects are not natively serializable to JSON.
         serialized_data = {

--- a/etl_entities/hwm_store/base_hwm_store.py
+++ b/etl_entities/hwm_store/base_hwm_store.py
@@ -22,14 +22,12 @@ class BaseHWMStore(BaseModel, ABC):
         Examples
         --------
 
-        .. code:: python
-
-            from etl_entities.hwm_store import HWMStoreStackManager
-
-            with SomeHWMStore(...) as hwm_store:
-                assert HWMStoreStackManager.get_current() == hwm_store
-
-            assert HWMStoreStackManager.get_current() == default_hwm_store
+        >>> from etl_entities.hwm_store import HWMStoreStackManager
+        >>> with SomeHWMStore(...) as hwm_store:
+        ...     print(HWMStoreStackManager.get_current())
+        SomeHWMStore(...)
+        >>> HWMStoreStackManager.get_current()
+        DefaultHWMStore()
         """
         # hack to avoid circular imports
         from etl_entities.hwm_store.hwm_store_stack_manager import HWMStoreStackManager

--- a/etl_entities/hwm_store/hwm_store_class_registry.py
+++ b/etl_entities/hwm_store/hwm_store_class_registry.py
@@ -23,16 +23,15 @@ class HWMStoreClassRegistry:
         Examples
         --------
 
-        .. code:: python
-
-            from etl_entities.hwm_store import HWMStoreClassRegistry, MemoryHWMStore
-
-            HWMStoreClassRegistry.get("memory") == MemoryHWMStore
-
-            HWMStoreClassRegistry.get("unknown")  # raise KeyError
-
-            HWMStoreClassRegistry.get()  # some default HWM Store, see `set_default`
-
+        >>> from etl_entities.hwm_store import HWMStoreClassRegistry
+        >>> HWMStoreClassRegistry.get("memory")
+        <class 'etl_entities.hwm_store.memory_hwm_store.MemoryHWMStore'>
+        >>> HWMStoreClassRegistry.get("unknown")
+        Traceback (most recent call last):
+            ...
+        KeyError: "Unknown HWM Store type 'unknown'"
+        >>> HWMStoreClassRegistry.get()  # some default HWM Store, see `set_default`
+        <class 'NoneType'>
         """
         if not alias:
             return cls._default
@@ -54,19 +53,16 @@ class HWMStoreClassRegistry:
         Examples
         --------
 
-        .. code:: python
+        >>> from etl_entities.hwm_store import HWMStoreClassRegistry, BaseHWMStore
+        >>> HWMStoreClassRegistry.get("my_store")  # raise KeyError
+        Traceback (most recent call last):
+            ...
+        KeyError: "Unknown HWM Store type 'my_store'"
 
-            from etl_entities.hwm_store import HWMStoreClassRegistry, BaseHWMStore
-
-            HWMStoreClassRegistry.get("my_store")  # raise KeyError
-
-
-            class MyHWMStore(BaseHWMStore): ...
-
-
-            HWMStoreClassRegistry.add("my_store", MyHWMStore)
-            HWMStoreClassRegistry.get("my_store") == MyHWMStore
-
+        >>> class MyHWMStore(BaseHWMStore): ...
+        >>> HWMStoreClassRegistry.add("my_store", MyHWMStore)
+        >>> HWMStoreClassRegistry.get("my_store")
+        <class 'etl_entities.hwm_store.hwm_store_class_registry.MyHWMStore'>
         """
         assert isinstance(alias, str)  # noqa: S101
         assert issubclass(klass, BaseHWMStore)  # noqa: S101
@@ -80,18 +76,11 @@ class HWMStoreClassRegistry:
         Examples
         --------
 
-        .. code-block:: python
-
-            from etl_entities.hwm_store import HWMStoreClassRegistry, BaseHWMStore
-
-
-            class MyHWMStore(BaseHWMStore): ...
-
-
-            HWMStoreClassRegistry.set_default(MyHWMStore)
-
-            assert HWMStoreClassRegistry.get() == MyHWMStore
-
+        >>> from etl_entities.hwm_store import HWMStoreClassRegistry, BaseHWMStore
+        >>> class MyHWMStore(BaseHWMStore): ...
+        >>> HWMStoreClassRegistry.set_default(MyHWMStore)
+        >>> HWMStoreClassRegistry.get()
+        <class 'etl_entities.hwm_store.hwm_store_class_registry.MyHWMStore'>
         """
         cls._default = klass
 

--- a/etl_entities/hwm_store/hwm_store_stack_manager.py
+++ b/etl_entities/hwm_store/hwm_store_stack_manager.py
@@ -39,14 +39,12 @@ class HWMStoreStackManager:
         Examples
         --------
 
-        .. code:: python
-
-            from etl_entities.hwm_store import HWMStoreStackManager
-
-            with SomeHWMStore(...) as hwm_store:
-                assert HWMStoreStackManager.get_current() == hwm_store
-
-            assert HWMStoreStackManager.get_current() == default_hwm_store
+        >>> from etl_entities.hwm_store import HWMStoreStackManager
+        >>> with SomeHWMStore(...) as hwm_store:
+        ...     print(HWMStoreStackManager.get_current())
+        SomeHWMStore(...)
+        >>> HWMStoreStackManager.get_current()
+        DefaultHWMStore()
         """
         if cls._stack:
             return cls._stack[-1]

--- a/etl_entities/hwm_store/memory_hwm_store.py
+++ b/etl_entities/hwm_store/memory_hwm_store.py
@@ -29,27 +29,18 @@ class MemoryHWMStore(BaseHWMStore):
     Examples
     --------
 
-    .. code:: python
-
-        from etl_entities.hwm_store import MemoryHWMStore
-        from etl_entities.hwm import ColumnIntHWM
-
-        hwm_store = MemoryHWMStore()
-
-        # not found
-        retrieved_hwm = hwm_store.get_hwm("long_unique_name")
-        assert hwm_store.get_hwm("long_unique_name") is None
-
-        hwm = ColumnIntHWM(name="long_unique_name", value=10)
-        hwm_store.set_hwm(hwm_value)
-
-        # found
-        retrieved_hwm = hwm_store.get_hwm("long_unique_name")
-        assert retrieved_hwm == hwm
-
-        hwm_store.clear()
-        # not found again
-        assert hwm_store.get_hwm("long_unique_name") is None
+    >>> from etl_entities.hwm_store import MemoryHWMStore
+    >>> from etl_entities.hwm import ColumnIntHWM
+    >>> hwm_store = MemoryHWMStore()
+    >>> retrieved_hwm = hwm_store.get_hwm("long_unique_name")
+    >>> hwm_store.get_hwm("long_unique_name") # not found
+    >>> hwm = ColumnIntHWM(name="long_unique_name", value=10)
+    >>> hwm_store.set_hwm(hwm)
+    >>> got_hwm = hwm_store.get_hwm("long_unique_name") # found
+    >>> got_hwm == hwm
+    True
+    >>> hwm_store.clear()
+    >>> hwm_store.get_hwm("long_unique_name") # not found again
     """
 
     _data: Dict[str, dict] = PrivateAttr(default_factory=dict)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 testpaths = tests
-norecursedirs = .git etl_entities
+norecursedirs = .git venv
 cache_dir = .pytest_cache
 log_cli_level = INFO
+addopts = --doctest-modules --ignore-glob="tests/libs/**"

--- a/tests/test_hwm/test_column_hwm.py
+++ b/tests/test_hwm/test_column_hwm.py
@@ -392,7 +392,7 @@ def test_column_hwm_unregistered_type(hwm_class):
     class UnregisteredHWM(hwm_class):
         pass  # noqa: WPS604
 
-    err_msg = r"You should register <class \'.*'> class using @register_hwm_type decorator"
+    err_msg = f"You should register '{UnregisteredHWM.__qualname__}' class using @register_hwm_type decorator"
 
     with pytest.raises(KeyError, match=err_msg):
         HWMTypeRegistry.get_key(UnregisteredHWM)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://github.com/MobileTeleSystems/etl-entities/blob/develop/CONTRIBUTING.rst for help on Contributing -->
<!-- PLEASE DO **NOT** put issue ids in the PR title! Instead, add a descriptive title and put ids in the body -->

## Change Summary

Instead of syntax:
```python
assert some == "other"
```
Use doctest style:
```python
>>> some
"other"
```

This should make examples easier to understand. See https://etl-entities--91.org.readthedocs.build/en/91/.

Also run pytest on these docstrings, to increase coverage.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [X] `docs/changelog/next_release/<pull request or issue id>.<change type>.rst` file added describing change
  (see [CONTRIBUTING.rst](https://github.com/MobileTeleSystems/etl-entities/blob/develop/CONTRIBUTING.rst) for details.)
* [x] My PR is ready to review.
